### PR TITLE
implement tcp server skeleton ; add command line args for server mode and unsafe mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ info: done! Mixed Z BTC now deposited in address:
 ### Running
 
     > stack exec refraction-exe
+    > stack exec refraction-exe -b  # run as bob (fairexchange server)
+    > stack-exec refraction-exe -i  # ignore input key/address validation
 
 ### Releasing
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -27,6 +27,7 @@ readConfig =
 
 main :: IO ()
 main = do
+    let isBob = True
     config <- readConfig
     T.putStr "Enter source private key (WIF encoded): "
     hFlush stdout
@@ -34,4 +35,4 @@ main = do
     putStr "Enter destination address (Base58 encoded): "
     hFlush stdout
     pubkey <- T.getLine
-    R.refract (network (bitcoin config)) prvkey pubkey
+    R.refract (network (bitcoin config)) isBob prvkey pubkey

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,10 +14,13 @@ import qualified Refraction as R
 
 -- Specify config file format
 data RefractionConfig = RefractionConfig { bitcoin :: BitcoinConfig } deriving Show
+
 data BitcoinConfig = BitcoinConfig { network :: Text } deriving Show
+
 instance FromJSON RefractionConfig where
     parseJSON (Object m) = RefractionConfig <$> m .: "bitcoin"
     parseJSON x = fail ("not an object: " ++ show x)
+
 instance FromJSON BitcoinConfig where
     parseJSON (Object m) = BitcoinConfig <$> m .: "network"
     parseJSON x = fail ("not an object: " ++ show x)
@@ -25,28 +28,37 @@ instance FromJSON BitcoinConfig where
 readConfig :: IO RefractionConfig
 readConfig = either (error . show) id <$> decodeFileEither ".refraction.yaml"
 
+
 -- Specify options
-data Options = Options  { optIsBob  :: Bool }
+data Options = Options  { optIsBob :: Bool, optIgnore :: Bool }
+
 defaultOptions :: Options
-defaultOptions = Options { optIsBob = False }
+defaultOptions = Options { optIsBob = False, optIgnore = False }
+
 options :: [OptDescr (Options -> IO Options)]
 options = [
-    Option ['b'] ["isbob"]   (NoArg showBob)   "run as Bob (server)"
+    Option ['b'] ["isbob"]   (NoArg showBob)   "run as Bob (server)",
+    Option ['i'] ["ignore-validation"] (NoArg showIgnore) "ignore key validation (not recommended)"
   ]
+
 showBob opt = do
     putStrLn "Running Refraction as Bob (server)"
     return opt { optIsBob = True }
+
+showIgnore opt = do
+    putStrLn "WARNING: Ignoring key validation"
+    return opt { optIgnore = True }
 
 readOptions = do
   args <- getArgs
   let (actions, nonOpts, msgs) = getOpt RequireOrder options args
   opts <- foldl (>>=) (return defaultOptions) actions
-  let Options { optIsBob = isBob } = opts
-  return isBob
+  let Options { optIsBob = isBob, optIgnore = ignoreValidation } = opts
+  return (isBob, ignoreValidation)
 
 
-runRefraction :: Bool -> IO ()
-runRefraction isBob = do
+runRefraction :: Bool -> Bool -> IO ()
+runRefraction isBob ignoreValidation = do
     config <- readConfig
     T.putStr "Enter source private key (WIF encoded): "
     hFlush stdout
@@ -54,8 +66,8 @@ runRefraction isBob = do
     putStr "Enter destination address (Base58 encoded): "
     hFlush stdout
     pubkey <- T.getLine
-    R.refract (network (bitcoin config)) isBob prvkey pubkey
+    R.refract (network (bitcoin config)) isBob ignoreValidation prvkey pubkey
 
 main = do
-    isBob <- readOptions
-    runRefraction isBob
+    (isBob, ignoreValidation) <- readOptions
+    runRefraction isBob ignoreValidation

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,19 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
+import System.Console.GetOpt
+import System.Environment
 import System.IO
 import Control.Applicative
+import Data.Maybe (fromMaybe)
 import Data.Yaml
 import Data.Text (Text)
 import qualified Data.Text.IO as T
 import qualified Refraction as R
 
-data RefractionConfig = RefractionConfig {
-    bitcoin :: BitcoinConfig
-} deriving Show
-data BitcoinConfig = BitcoinConfig {
-    network :: Text
-} deriving Show
+
+-- Specify config file format
+data RefractionConfig = RefractionConfig { bitcoin :: BitcoinConfig } deriving Show
+data BitcoinConfig = BitcoinConfig { network :: Text } deriving Show
 instance FromJSON RefractionConfig where
     parseJSON (Object m) = RefractionConfig <$> m .: "bitcoin"
     parseJSON x = fail ("not an object: " ++ show x)
@@ -22,12 +23,30 @@ instance FromJSON BitcoinConfig where
     parseJSON x = fail ("not an object: " ++ show x)
 
 readConfig :: IO RefractionConfig
-readConfig =
-    either (error . show) id <$> decodeFileEither ".refraction.yaml"
+readConfig = either (error . show) id <$> decodeFileEither ".refraction.yaml"
 
-main :: IO ()
-main = do
-    let isBob = True
+-- Specify options
+data Options = Options  { optIsBob  :: Bool }
+defaultOptions :: Options
+defaultOptions = Options { optIsBob = False }
+options :: [OptDescr (Options -> IO Options)]
+options = [
+    Option ['b'] ["isbob"]   (NoArg showBob)   "run as Bob (server)"
+  ]
+showBob opt = do
+    putStrLn "Running Refraction as Bob (server)"
+    return opt { optIsBob = True }
+
+readOptions = do
+  args <- getArgs
+  let (actions, nonOpts, msgs) = getOpt RequireOrder options args
+  opts <- foldl (>>=) (return defaultOptions) actions
+  let Options { optIsBob = isBob } = opts
+  return isBob
+
+
+runRefraction :: Bool -> IO ()
+runRefraction isBob = do
     config <- readConfig
     T.putStr "Enter source private key (WIF encoded): "
     hFlush stdout
@@ -36,3 +55,7 @@ main = do
     hFlush stdout
     pubkey <- T.getLine
     R.refract (network (bitcoin config)) isBob prvkey pubkey
+
+main = do
+    isBob <- readOptions
+    runRefraction isBob

--- a/refraction.cabal
+++ b/refraction.cabal
@@ -16,9 +16,11 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Refraction
+                     , PeerToPeer
   build-depends:       base >= 4.7 && < 5
                      , text
                      , haskoin-core
+                     , network
   default-language:    Haskell2010
 
 executable refraction-exe

--- a/src/PeerToPeer.hs
+++ b/src/PeerToPeer.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+module PeerToPeer
+    ( startServer
+    , startClient
+    ) where
+
+
+import Control.Monad (liftM)
+import Network.Socket
+import System.IO
+
+runConn :: (Socket, SockAddr) -> Int -> IO ()
+runConn (sock, _) msgNum = do
+    hdl <- socketToHandle sock ReadWriteMode
+    hSetBuffering hdl NoBuffering
+
+    name <- liftM init (hGetLine hdl)
+    hPutStrLn hdl "hi"
+    name <- liftM init (hGetLine hdl)
+
+    hClose hdl
+
+mainLoop :: Socket -> Int -> IO ()
+mainLoop sock msgNum = do
+  conn <- accept sock
+  runConn conn msgNum
+
+startServer :: IO ()
+startServer = do
+    sock <- socket AF_INET Stream 0
+    setSocketOption sock ReuseAddr 1
+    bind sock (SockAddrInet 4242 iNADDR_ANY)
+    listen sock 2
+    mainLoop sock 0
+
+startClient :: IO ()
+startClient = undefined

--- a/src/Refraction.hs
+++ b/src/Refraction.hs
@@ -28,11 +28,11 @@ isValidAddress addr = case C.base58ToAddr (TE.encodeUtf8 addr) of
 handleBadAddress :: T.Text -> IO()
 handleBadAddress addr = putStrLn "ERROR: address is not valid"
 
-refract :: T.Text -> Bool -> T.Text -> T.Text -> IO ()
-refract network isBob prv addr = do
+refract :: T.Text -> Bool -> Bool -> T.Text -> T.Text -> IO ()
+refract network isBob ignoreValidation prv addr = do
     TI.putStrLn $ T.append "INFO: Starting refraction on " network
     case () of
-      _ | not (isValidPrivateKey prv) -> handleBadPrvkey prv
-        | not (isValidAddress addr) -> handleBadAddress addr
+      _ | not (ignoreValidation || isValidPrivateKey prv) -> handleBadPrvkey prv
+        | not (ignoreValidation || isValidAddress addr) -> handleBadAddress addr
         | isBob -> P2P.startServer
         | otherwise -> P2P.startClient

--- a/src/Refraction.hs
+++ b/src/Refraction.hs
@@ -5,6 +5,7 @@ module Refraction
     , refract
     ) where
 
+import qualified PeerToPeer as P2P
 import qualified Data.Text as T
 import qualified Data.Text.IO as TI
 import qualified Data.Text.Encoding as TE
@@ -27,10 +28,11 @@ isValidAddress addr = case C.base58ToAddr (TE.encodeUtf8 addr) of
 handleBadAddress :: T.Text -> IO()
 handleBadAddress addr = putStrLn "ERROR: address is not valid"
 
-refract :: T.Text -> T.Text -> T.Text -> IO ()
-refract network prv addr = do
+refract :: T.Text -> Bool -> T.Text -> T.Text -> IO ()
+refract network isBob prv addr = do
     TI.putStrLn $ T.append "INFO: Starting refraction on " network
     case () of
       _ | not (isValidPrivateKey prv) -> handleBadPrvkey prv
         | not (isValidAddress addr) -> handleBadAddress addr
-        | otherwise -> return ()
+        | isBob -> P2P.startServer
+        | otherwise -> P2P.startClient


### PR DESCRIPTION
I added 2 flags `-b` and `-i` for "is bob" and "ignore validation". The former decides to run the server side of the FairExchange (we'll make Bob always be the server to start). The latter removes the validation of the input keys just to make testing this locally easier

ref #12 