### PR TITLE
implement a transaction broadcast function

### DIFF
--- a/refraction.cabal
+++ b/refraction.cabal
@@ -25,6 +25,7 @@ library
                      , bytestring
                      , cereal
                      , haskoin-core
+                     , http-client
                      , lens
                      , network
                      , random

--- a/src/Blockchain.hs
+++ b/src/Blockchain.hs
@@ -1,54 +1,77 @@
 {-# LANGUAGE DeriveGeneric, OverloadedStrings #-}
 module Blockchain
     ( broadcast
+    , transaction
     , utxos
     ) where
 
+import Control.Exception (try)
 import Control.Lens
-import Data.Aeson (FromJSON)
+import Data.Aeson (FromJSON, ToJSON, toJSON)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
 import Data.Maybe (fromMaybe)
 import Data.Serialize (decode)
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
+import Data.Word (Word32)
+import Generator (SatoshiValue, UTXO(..))
 import GHC.Generics (Generic)
 import Network.Haskoin.Crypto (Address, addrToBase58)
-import Network.Haskoin.Transaction (hexToTxHash, Tx, TxHash, txHashToHex)
+import Network.Haskoin.Transaction (hexToTxHash, OutPoint(..), Tx, TxHash, TxOut(..), txHashToHex)
 import Network.Haskoin.Util (decodeHex, decodeToMaybe)
+import Network.HTTP.Client (HttpException(..))
 import Network.Wreq
 
 baseURL = "https://testnet.blockexplorer.com/api"
 
-broadcast :: Tx -> IO ()
-broadcast tx = undefined
-
-data ResponseTransaction = ResponseTransaction {
-      rawtx :: Text
+data TxPayload = TxPayload {
+      rawtx :: Tx
 } deriving (Generic)
 
-instance FromJSON ResponseTransaction
+instance FromJSON TxPayload
+
+instance ToJSON TxPayload
+
+data ResponseBroadcast = ResponseBroadcast {
+      _transaction :: Tx
+} deriving (Generic)
+
+instance FromJSON ResponseBroadcast
+
+broadcast :: Tx -> IO ()
+broadcast tx = do
+    let url = baseURL ++ "/tx/send"
+    eresponse <- try $ post url (toJSON $ TxPayload tx)
+    case eresponse of
+        Left e -> print (e :: HttpException)
+        Right response -> asJSON response >>= printTransaction
+  where
+    printTransaction r = putStrLn . show . _transaction $ r ^. responseBody
 
 transaction :: TxHash -> IO Tx
 transaction txhash = do
     let url = baseURL ++ "/rawtx/" ++ B8.unpack (txHashToHex txhash)
     r <- asJSON =<< get url
-    let tx = decode . fromMaybe undefined . decodeHex . encodeUtf8 . rawtx $ r ^. responseBody
-    return $ either undefined id tx -- YOLO
+    return . rawtx $ r ^. responseBody
 
 data ResponseUTXO = ResponseUTXO {
-      txid :: Text
-    , vout :: Int
+      txid :: TxHash
+    , vout :: Word32
+    , satoshis :: SatoshiValue
+    , scriptPubKey :: Text
 } deriving (Generic)
 
 instance FromJSON ResponseUTXO
 
-utxos :: Address -> IO [(Tx, Int)]
+toUTXO :: ResponseUTXO -> UTXO
+toUTXO r = UTXO txOut outPoint
+  where
+    txOut = TxOut (satoshis r) (fromMaybe undefined . decodeHex . encodeUtf8 . scriptPubKey $ r)
+    outPoint = OutPoint (txid r)  (vout r)
+
+utxos :: Address -> IO [UTXO]
 utxos addr = do
     let url = baseURL ++ "/addr/" ++ B8.unpack (addrToBase58 addr) ++ "/utxo"
     r <- asJSON =<< get url
-    let utxos = r ^. responseBody :: [ResponseUTXO]
-    sequence $ map fetchUTXO utxos
-  where
-    fetchUTXO utxo = getTx utxo >>= (\tx -> return (tx, vout utxo))
-    getTx = transaction . fromMaybe undefined . hexToTxHash . encodeUtf8 . txid
+    return . map toUTXO $ r ^. responseBody

--- a/src/Discover.hs
+++ b/src/Discover.hs
@@ -47,7 +47,8 @@ publishAd = do
     let location = undefined
     let opreturnData = makeAdData [location, nonce]
     let utxos = undefined
-    let tx = either undefined id $ makeAdTransaction utxos opreturnData tao :: Tx
+    let keys = undefined
+    let tx = either undefined id $ makeAdTransaction utxos keys opreturnData tao :: Tx
     broadcast tx
 
 -- Advertiser: select respondent R, store sigAPK(nA paired to h(nR))" to alphaA

--- a/src/Generator.hs
+++ b/src/Generator.hs
@@ -4,6 +4,7 @@ module Generator
     , makeAdData
     , makeAdTransaction
     , SatoshiValue
+    , UTXO(..)
     ) where
 
 import Data.ByteString (ByteString)
@@ -16,17 +17,16 @@ type SatoshiValue = Word64
 data UTXO = UTXO {
       _txOut :: TxOut
     , _outPoint :: OutPoint
-    , _prvKey :: PrvKey
-}
+} deriving (Show)
 
 instance Coin UTXO where
     coinValue =  outValue . _txOut
 
-makeSimpleTransaction :: [UTXO] -> Address -> Either String Tx
+makeSimpleTransaction :: [UTXO] -> [PrvKey] -> Address -> Either String Tx
 makeSimpleTransaction utxos addr = undefined
 
 -- |Takes coins to sign, the data to place in the OP_RETURN and the miner's fee value
-makeAdTransaction :: [UTXO] -> ByteString -> SatoshiValue -> Either String Tx
+makeAdTransaction :: [UTXO] -> [PrvKey] -> ByteString -> SatoshiValue -> Either String Tx
 makeAdTransaction = undefined
 
 -- |Takes a list of items and serializes so it is ready to be placed in a Tx


### PR DESCRIPTION
use http-client style exception handling for broadcast failures.

For example, the current hardcoded address in testBlockchain should fail
at the broadcast step because the transaction is already present in the
blockchain