### PR TITLE
Wait for an Ad on the blockchain (most recent 10 blocks)

### DIFF
--- a/demo-opreturn.js
+++ b/demo-opreturn.js
@@ -1,0 +1,34 @@
+var bitcore = require('bitcore');
+console.log('hello');
+
+
+// use bx ec-new -c data/bx-testnet.cfg
+// bx ec-to-wif <ec key>
+var privateKey = new bitcore.PrivateKey('cQrgind4kVZbZpfAVfZq8Nw6HcPBZyT2pktrn2t5dSS7H9aeNFmx');
+// bx ec-to-public <ec key>
+// bx ec-to-address <ec public key>
+// moCvBdctTGGBwquWx647GvQWAsr4XBQBXh
+
+// use haskoin faucet to get some coins http://faucet.xeno-genesis.com/
+// use https://testnet.blockexplorer.com/ to find the faucet transactions
+var utxo = {
+  "txId" : "94361af4c3fc113fcb705eca3d90368d3c3be7e5b9d803808f64d1ab41f0c8da",
+  "outputIndex" : 1,
+  "address" : "moCvBdctTGGBwquWx647GvQWAsr4XBQBXh",
+// get the script from going to https://testnet.blockexplorer.com/tx/<tx hash> and looking for
+// the script in the right output. It's probably not the first output
+  "script" : "76a9145457c1cbd45710c749b7aba24f9d9e97382893d588ac",
+// haskoin faucet gives 0.001 btc (100000 satoshis)
+  "satoshis" : 100000
+};
+
+
+var transaction = new bitcore.Transaction()
+      .from(utxo)
+  // this is the message refraction currently looks for
+      .addData("RFRCTN")
+      .change("moCvBdctTGGBwquWx647GvQWAsr4XBQBXh")
+      .sign([privateKey])
+
+var serialized = transaction.toString();
+console.log(serialized);

--- a/demo-opreturn.js
+++ b/demo-opreturn.js
@@ -12,7 +12,7 @@ var privateKey = new bitcore.PrivateKey('cQrgind4kVZbZpfAVfZq8Nw6HcPBZyT2pktrn2t
 // use haskoin faucet to get some coins http://faucet.xeno-genesis.com/
 // use https://testnet.blockexplorer.com/ to find the faucet transactions
 var utxo = {
-  "txId" : "94361af4c3fc113fcb705eca3d90368d3c3be7e5b9d803808f64d1ab41f0c8da",
+  "txId" : "1c7a7f9488d330c60363c2ceed8417c8b44bdcf131a9e53a798d59adaa0f1e44",
   "outputIndex" : 1,
   "address" : "moCvBdctTGGBwquWx647GvQWAsr4XBQBXh",
 // get the script from going to https://testnet.blockexplorer.com/tx/<tx hash> and looking for
@@ -31,4 +31,5 @@ var transaction = new bitcore.Transaction()
       .sign([privateKey])
 
 var serialized = transaction.toString();
+// use https://testnet.blockexplorer.com/tx/send to broadcast
 console.log(serialized);

--- a/refraction.cabal
+++ b/refraction.cabal
@@ -34,6 +34,7 @@ library
                      , haskoin-core
                      , http-client
                      , lens
+                     , lens-aeson
                      , monadcryptorandom
                      , network
                      , network-anonymous-tor

--- a/src/Blockchain.hs
+++ b/src/Blockchain.hs
@@ -101,7 +101,7 @@ fetchRecentBlocks = do
     let url = baseURL ++ "/status?q=getLastBlockHash"
     r <- get url
     let lastBlockHash = encodeUtf8 $ r ^. responseBody . key "lastblockhash" . _String
-    fetchBlockchain (fromMaybe undefined $ hexToBlockHash lastBlockHash) 3
+    fetchBlockchain (fromMaybe undefined $ hexToBlockHash lastBlockHash) 10
   where
     fetchBlockchain :: BlockHash -> Int -> IO [Block]
     fetchBlockchain tipHash depth

--- a/src/Blockchain.hs
+++ b/src/Blockchain.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric, OverloadedStrings #-}
 module Blockchain
     ( broadcast
+    , findOPRETURNs
     , transaction
     , utxos
     ) where
@@ -8,17 +9,21 @@ module Blockchain
 import Control.Exception (try)
 import Control.Lens
 import Data.Aeson (FromJSON, ToJSON, toJSON)
+import Data.Aeson.Lens (_String, key)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
+import Data.List (union)
 import Data.Maybe (fromMaybe)
-import Data.Serialize (decode)
-import Data.Text (Text)
-import Data.Text.Encoding (encodeUtf8)
+import qualified Data.Serialize as S
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Word (Word32)
 import Generator (SatoshiValue, UTXO(..))
 import GHC.Generics (Generic)
+import Network.Haskoin.Block (Block, BlockHash, blockHashToHex, blockHeader, blockTxns, headerHash, hexToBlockHash, prevBlock)
 import Network.Haskoin.Crypto (Address, addrToBase58)
-import Network.Haskoin.Transaction (hexToTxHash, OutPoint(..), Tx, TxHash, TxOut(..), txHashToHex)
+import Network.Haskoin.Script (Script, ScriptOp(..), scriptOps)
+import Network.Haskoin.Transaction (hexToTxHash, OutPoint(..), scriptOutput, Tx, TxHash, txOut, TxOut(..), txHashToHex)
 import Network.Haskoin.Util (decodeHex, decodeToMaybe)
 import Network.HTTP.Client (HttpException(..))
 import Network.Wreq
@@ -59,7 +64,7 @@ data ResponseUTXO = ResponseUTXO {
       txid :: TxHash
     , vout :: Word32
     , satoshis :: SatoshiValue
-    , scriptPubKey :: Text
+    , scriptPubKey :: T.Text
 } deriving (Generic)
 
 instance FromJSON ResponseUTXO
@@ -75,3 +80,37 @@ utxos addr = do
     let url = baseURL ++ "/addr/" ++ B8.unpack (addrToBase58 addr) ++ "/utxo"
     r <- asJSON =<< get url
     return . map toUTXO $ r ^. responseBody
+
+findOPRETURNs :: [BlockHash] -> IO ([[ScriptOp]], [BlockHash])
+findOPRETURNs excludes = do
+    recentBlocks <- fetchRecentBlocks
+    let blocks = filter (\b -> blockHash b `notElem` excludes) recentBlocks
+        findTxns = filter isDataCarrier . map firstScript . concat . map blockTxns
+    return (findTxns blocks, excludes `union` map blockHash blocks)
+  where
+    blockHash = headerHash . blockHeader
+    firstScript :: Tx -> [ScriptOp]
+    firstScript = scriptOps . either undefined id . S.decode . scriptOutput . head . txOut
+    -- TODO: use Haskoin DataCarrier logic instead once released
+    isDataCarrier :: [ScriptOp] -> Bool
+    isDataCarrier [OP_RETURN, OP_PUSHDATA _ _] = True
+    isDataCarrier _ = False
+
+fetchRecentBlocks :: IO [Block]
+fetchRecentBlocks = do
+    let url = baseURL ++ "/status?q=getLastBlockHash"
+    r <- get url
+    let lastBlockHash = encodeUtf8 $ r ^. responseBody . key "lastblockhash" . _String
+    fetchBlockchain (fromMaybe undefined $ hexToBlockHash lastBlockHash) 3
+  where
+    fetchBlockchain :: BlockHash -> Int -> IO [Block]
+    fetchBlockchain tipHash depth
+        | depth < 1 = return []
+        | otherwise = do
+            let url = concat [baseURL, "/block/", B8.unpack $ blockHashToHex tipHash]
+            r <- get url
+            let b = toBlock $ r ^. responseBody . key "rawblock" . _String
+            prevBlocks <- fetchBlockchain (prevBlock (blockHeader b)) (depth - 1)
+            return $ b : prevBlocks
+    toBlock :: T.Text -> Block
+    toBlock = either undefined id . S.decode . fromMaybe undefined . decodeHex . encodeUtf8

--- a/src/Blockchain.hs
+++ b/src/Blockchain.hs
@@ -107,7 +107,7 @@ fetchRecentBlocks = do
     fetchBlockchain tipHash depth
         | depth < 1 = return []
         | otherwise = do
-            let url = concat [baseURL, "/block/", B8.unpack $ blockHashToHex tipHash]
+            let url = concat [baseURL, "/rawblock/", B8.unpack $ blockHashToHex tipHash]
             r <- get url
             let b = toBlock $ r ^. responseBody . key "rawblock" . _String
             prevBlocks <- fetchBlockchain (prevBlock (blockHeader b)) (depth - 1)

--- a/src/Discover.hs
+++ b/src/Discover.hs
@@ -56,8 +56,8 @@ selectAdvertiser = do
         (opreturns, newExcludes) <- findOPRETURNs excludeHashes
         let adM = find isAd opreturns
         case adM of
-            -- If there were no ads, sleep for 10 seconds and try again
-            Nothing -> threadDelay 10000000 >> findAd' newExcludes
+            -- If there were no ads, sleep for 30 seconds and try again
+            Nothing -> threadDelay 30000000 >> findAd' newExcludes
             Just ad -> return ad
     isAd [OP_RETURN, OP_PUSHDATA bs _] = "RFRCTN" == decodeUtf8 bs
     isAd _ = False

--- a/src/Discover.hs
+++ b/src/Discover.hs
@@ -8,13 +8,18 @@ module Discover
     , Location
     ) where
 
-import Blockchain (broadcast)
+import Blockchain (broadcast, findOPRETURNs)
 import Control.Concurrent.Chan (Chan, readChan)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B8
+import Data.List (find)
+import Control.Concurrent (threadDelay)
+import Data.Serialize as S
 import Data.Text.Encoding (decodeUtf8)
 import Generator (makeAdData, makeAdTransaction, SatoshiValue)
-import Network.Haskoin.Transaction (Tx)
+import Network.Haskoin.Block (BlockHash)
+import Network.Haskoin.Script (Script, ScriptOp(..), scriptOps)
+import Network.Haskoin.Transaction (scriptOutput, Tx, txOut)
 import PeerToPeer (Msg, sendMessage, unsecureSend)
 import System.Random (getStdRandom, randomR)
 import Tor(secureConnect)
@@ -39,11 +44,23 @@ discover chan myLoc isBob isAlice = flipCoin >>= pickRole
 selectAdvertiser :: IO Location
 selectAdvertiser = do
     let theirLocation = "L4TSUOJSZU23TPQZ.onion"
+    ad <- findAd
     -- TODO: we can't use Tor until we have the ad transaction on the blockchain
     -- stuff working because the locations are dynamic. Use direct connection for now.
     --secureConnect theirLocation (sendMessage "i am alice, wanna trade bitcoins?")
     unsecureSend False "i am alice, wanna trade bitcoins?"
     return theirLocation
+  where
+    findAd = findAd' []
+    findAd' excludeHashes = do
+        (opreturns, newExcludes) <- findOPRETURNs excludeHashes
+        let adM = find isAd opreturns
+        case adM of
+            -- If there were no ads, sleep for 10 seconds and try again
+            Nothing -> threadDelay 10000000 >> findAd' newExcludes
+            Just ad -> return ad
+    isAd [OP_RETURN, OP_PUSHDATA bs _] = "RFRCTN" == decodeUtf8 bs
+    isAd _ = False
 
 -- Respondent: publishes T{R -> R, tip = tao + extra, TEXT(id = encAPK(nA, nR))}
 publishPairRequest :: IO ()


### PR DESCRIPTION
currently polls for the last 10 blocks every 10 seconds... this'll
be improved later but is simple and works for now


TODO: I still need to clean this up in later PRs

To test this:

in one session, run bob (the "advertiser")
```
stack exec refraction-exe -- -i -b
```

in another session, run alice (the "responder")
```
stack exec refraction-exe -- -i -a
```

in a third session, pretend to be bob posting an ad (because ad generation doesn't exist yet):
```
vi demo-opreturn.js
node demo-opreturn.js  # broadcast on testnet.blockexplorer.com
```

Then just wait for the transaction to confirm, and Alice should pick it up and contact bob and they both proceed to fairexchange