### PR TITLE
create Bob commit transaction using P2SH and CLTV

### DIFF
--- a/demo-fairexchange.hs
+++ b/demo-fairexchange.hs
@@ -1,0 +1,41 @@
+import Control.Monad.CryptoRandom (crandomRs)
+import Crypto.Random.DRBG (CtrDRBG, newGenIO)
+import Control.Monad (guard, liftM)
+import Data.ByteString.Char8 hiding (putStrLn)
+import Data.Maybe
+import Data.Serialize
+import Generator
+import Network.Haskoin.Constants
+import Network.Haskoin.Crypto
+import Network.Haskoin.Transaction
+import Network.Haskoin.Util
+
+-- testnet address:moCvBdctTGGBwquWx647GvQWAsr4XBQBXh
+-- run with `stack runhaskell demo-fairexchange-txs.hs`
+-- use https://testnet.blockexplorer.com/tx/send to broadcast
+
+main = do
+    switchToTestnet3
+
+    let txhash = "TxHash \"8761f25393a6f3bdf3d57c39b380a2f1cbc92382a28e704c730bfdfd7a429012\""
+        n = 1
+        value = 100000
+        -- hex scriptSig
+        script = "76a9145457c1cbd45710c749b7aba24f9d9e97382893d588ac"
+        -- wif prvkey
+        p = "PrvKey \"cQrgind4kVZbZpfAVfZq8Nw6HcPBZyT2pktrn2t5dSS7H9aeNFmx\""
+        secret = 56 :: Integer
+
+    let utxo = toUTXO txhash n value script
+        prv = read p
+        pub = derivePubKey prv
+        hash = hash256 $ encode secret
+
+    let tx = either undefined id $ makeBobCommit [utxo] [prv] pub pub [hash]
+    putStrLn $ show tx
+
+toUTXO txhash n value script =
+    let s = fromMaybe undefined . decodeHex $ pack script
+        op = OutPoint { outPointHash=(read txhash), outPointIndex=n }
+        to = TxOut { outValue=value, scriptOutput=s }
+    in UTXO { _outPoint=op, _txOut=to }

--- a/src/Discover.hs
+++ b/src/Discover.hs
@@ -54,7 +54,7 @@ selectAdvertiser = do
     findAd = findAd' []
     findAd' excludeHashes = do
         (opreturns, newExcludes) <- findOPRETURNs excludeHashes
-        let adM = find isAd opreturns
+        let adM = find (isAd . scriptOps) opreturns
         case adM of
             -- If there were no ads, sleep for 30 seconds and try again
             Nothing -> threadDelay 30000000 >> findAd' newExcludes

--- a/src/FairExchange.hs
+++ b/src/FairExchange.hs
@@ -34,9 +34,9 @@ setupSecrets isBob chan _ = do
     keypair1 <- makeKeyPair
     keypair2 <- makeKeyPair
     let n = 20
-    let m = 5
+        m = 5
+        f = if isBob then setupBobSecrets else setupAliceSecrets
     mySecrets <- genSecrets n
-    let f = if isBob then setupBobSecrets else setupAliceSecrets
     f chan keypair1 keypair2 n m mySecrets
   where
     makeKeyPair = genKey >>= \p -> return (p, derivePubKey p)
@@ -63,9 +63,9 @@ setupBobSecrets :: Chan Msg -> KeyPair -> KeyPair -> Int -> Int -> [Secret] -> I
 setupBobSecrets chan (prvkey1, pubkey1) (prvkey2, pubkey2) n _ mySecrets = do
     aliceKeys <- liftM (fromMaybe undefined . decode) $ readChan chan
     let aliceSecrets = aSecrets aliceKeys
-    let bobHashes = map hashAndEncode mySecrets
-    let sums = zipWith (+) aliceSecrets mySecrets
-    let sumHashes = map hashAndEncode sums
+        bobHashes = map hashAndEncode mySecrets
+        sums = zipWith (+) aliceSecrets mySecrets
+        sumHashes = map hashAndEncode sums
     send $ BobKeyMessage pubkey1 pubkey2 bobHashes sumHashes
     indices <- liftM (fromMaybe undefined . decode) $ readChan chan
     send $ map ((!!) mySecrets) indices

--- a/src/Generator.hs
+++ b/src/Generator.hs
@@ -9,9 +9,9 @@ module Generator
 
 import Data.Word (Word64)
 import Data.ByteString (ByteString)
-import Network.Haskoin.Crypto (PrvKey, Address)
-import Network.Haskoin.Script (ScriptOutput(DataCarrier))
-import qualified Network.Haskoin.Script as S
+import qualified Data.Serialize as S
+import Network.Haskoin.Crypto (Address(..), getHash256, hash160, hash256, Hash256, PrvKey, PubKey)
+import Network.Haskoin.Script (decodeOutputBS, opPushData, Script(..), ScriptOp(..), ScriptOutput(..), SigHash(..))
 import qualified Network.Haskoin.Transaction as T
 
 type SatoshiValue = Word64
@@ -24,21 +24,51 @@ data UTXO = UTXO {
 instance T.Coin UTXO where
     coinValue =  T.outValue . _txOut
 
--- Default transaction fee
+-- Default transaction fee in satoshis
 dTxFee = 10000
 
 -- |Takes a UTXO and returns a SigInput that can be used to sign a Tx
 mkInput :: UTXO -> T.SigInput
-mkInput utxo = T.SigInput pso (_outPoint utxo) (S.SigAll False) Nothing
-  where pso = either undefined id . S.decodeOutputBS . T.scriptOutput $ _txOut utxo
+mkInput utxo = T.SigInput pso (_outPoint utxo) (SigAll False) Nothing
+  where pso = either undefined id . decodeOutputBS . T.scriptOutput $ _txOut utxo
+
+-- |Our miner fee grows linearly with the number of inputs
+calculateAmount :: [UTXO] -> SatoshiValue
+calculateAmount = foldl sumVal 0
+  where
+    sumVal v utxo = v + T.coinValue utxo - dTxFee
 
 -- |Takes a list of utxos and associated private keys and pays to an address
 makeSimpleTransaction :: [UTXO] -> [PrvKey] -> Address -> Either String T.Tx
 makeSimpleTransaction utxos prvkeys addr =
-    T.signTx tx (map mkInput utxos) prvkeys
-  where
-    sumVal v utxo = v + T.coinValue utxo - dTxFee
-    tx = either undefined id $ T.buildTx (map _outPoint utxos) [(S.PayPKHash addr, foldl sumVal 0 utxos)]
+    let tx = either undefined id $ T.buildTx (map _outPoint utxos) [(PayPKHash addr, calculateAmount utxos)]
+        in T.signTx tx (map mkInput utxos) prvkeys
+
+makeBobCommit :: [UTXO] -> [PrvKey] -> PubKey -> PubKey -> [Hash256] -> Either String T.Tx
+makeBobCommit utxos prvkeys aPubkey bPubkey bHashes =
+    let redeemScript = makeBobCommitRedeem aPubkey bPubkey bHashes 100000
+        scriptOut = PayScriptHash (scriptAddrNonStd redeemScript)
+        tx = either undefined id $ T.buildTx (map _outPoint utxos) [(scriptOut, calculateAmount utxos)]
+        in T.signTx tx (map mkInput utxos) prvkeys
+
+-- TODO put this is haskoin
+scriptAddrNonStd :: Script -> Address
+scriptAddrNonStd = ScriptAddress . hash160 . getHash256 . hash256 . S.encode
+
+makeBobCommitRedeem :: PubKey -> PubKey -> [Hash256] -> Integer -> Script
+makeBobCommitRedeem aPubkey bPubkey bHashes locktime =
+    Script $ [ OP_IF
+             -- OP_NOP2 is OP_CHECKLOCKTIMEVERIFY (CLTV)
+             , opPushData (S.encode locktime), OP_NOP2, OP_DROP
+             , opPushData (S.encode bPubkey), OP_CHECKSIG
+             , OP_ELSE
+             , opPushData (S.encode aPubkey), OP_CHECKSIGVERIFY
+             , OP_HASH256
+             ] ++
+             concat (map (\hash -> [OP_DUP, opPushData (S.encode hash), OP_EQUAL, OP_SWAP]) (init bHashes)) ++
+             [ opPushData $ S.encode (last bHashes), OP_EQUAL ] ++
+             replicate (length bHashes - 1) OP_BOOLOR ++
+             [ OP_ENDIF ]
 
 -- |Takes coins to sign, the data to place in the OP_RETURN and the miner's fee value
 makeAdTransaction :: [UTXO] -> [PrvKey] -> ByteString -> SatoshiValue -> Either String T.Tx

--- a/src/Generator.hs
+++ b/src/Generator.hs
@@ -3,6 +3,7 @@ module Generator
     ( makeSimpleTransaction
     , makeAdData
     , makeAdTransaction
+    , makeBobCommit
     , SatoshiValue
     , UTXO(..)
     ) where
@@ -59,6 +60,7 @@ makeBobCommitRedeem :: PubKey -> PubKey -> [Hash256] -> Integer -> Script
 makeBobCommitRedeem aPubkey bPubkey bHashes locktime =
     Script $ [ OP_IF
              -- OP_NOP2 is OP_CHECKLOCKTIMEVERIFY (CLTV)
+             -- TODO update haskoin with cltv op
              , opPushData (S.encode locktime), OP_NOP2, OP_DROP
              , opPushData (S.encode bPubkey), OP_CHECKSIG
              , OP_ELSE

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,10 +8,5 @@ packages:
   subdirs:
   - haskoin-core
   extra-dep: true
-extra-deps:
-- murmur3-1.0.2
-- pbkdf-1.1.1.1
-- secp256k1-0.4.6
-- text-1.2.2.1
-- yaml-0.8.17.2
-resolver: lts-6.4
+extra-deps: []
+resolver: lts-7.2


### PR DESCRIPTION
this isn't exactly as described in Xim, but using P2SH makes sure that
our non-standard transactions will get relayed. And using CLTV saves us
1 transaction (no need for a lock-time refund transaction
(hypothetically))