### PR TITLE
split funds on the initial prvkey to start multiple rounds

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,0 +1,1 @@
+--ignore-dir=.stack-work

--- a/.projectile
+++ b/.projectile
@@ -1,0 +1,1 @@
+-/node_modules

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,7 +6,6 @@ import System.Directory (doesFileExist)
 import System.Environment
 import System.IO
 import Control.Applicative
-import qualified Data.ByteString.Char8 as B8
 import Data.Maybe (fromMaybe)
 import Data.Yaml
 import Data.Text (Text)
@@ -70,18 +69,19 @@ runRefraction isBob isAlice ignoreValidation = do
 
     putStr "Enter destination address for mixed coins (Base58 encoded): "
     hFlush stdout
-    pubkey <- T.getLine
+    endAddr <- T.getLine
 
     putStr "Enter refund address for non-mixed coins that need to be refunded (Base58 encoded):"
     hFlush stdout
     refundAddr <- T.getLine
 
-    (_, refundAddr) <- BU.makeAddress
-    putStr "Send 1 transaction to this address to begin mixing: "
-    B8.putStrLn refundAddr
-    hFlush stdout
+    -- CURRENTLY UNUSED:
+    --(_, startAddr) <- BU.makeTextKeyPair
+    --putStr "Send funds to mix in 1 transaction to this address to begin mixing: "
+    --T.putStrLn startAddr
+    --hFlush stdout
 
-    R.refract config isBob isAlice ignoreValidation prvkey pubkey
+    R.refract config isBob isAlice ignoreValidation prvkey endAddr refundAddr
 
 main = do
     (isBob, isAlice, ignoreValidation) <- readOptions

--- a/refraction.cabal
+++ b/refraction.cabal
@@ -28,6 +28,7 @@ library
                      , Network.Refraction.FairExchange.Types
                      , Network.Refraction.Generator
                      , Network.Refraction.PeerToPeer
+                     , Network.Refraction.RoundManager
                      , Network.Refraction.Tor
 -- TODO: restrict these deps to safer ranges
   build-depends:       aeson

--- a/src/Network/Refraction.hs
+++ b/src/Network/Refraction.hs
@@ -12,15 +12,12 @@ import Data.Text (Text, append)
 import qualified Data.Text.IO as TI
 import qualified Data.Text.Encoding as TE
 import Data.Yaml
-import Network (PortNumber)
 import Network.Haskoin.Constants (switchToTestnet3)
 import Network.Haskoin.Transaction (OutPoint(..))
 import qualified Network.Haskoin.Crypto as C
-import Network.Refraction.Discover (discover)
-import Network.Refraction.FairExchange (fairExchange)
-import Network.Refraction.Generator (UTXO(..))
-import qualified Network.Refraction.PeerToPeer as P2P
-import Network.Refraction.Tor (makeHiddenService)
+
+import Network.Refraction.BitcoinUtils
+import Network.Refraction.RoundManager (prepareRounds)
 
 -- There may be a simpler way to express this, but this is our config file type declaration
 data RefractionConfig = RefractionConfig { bitcoin :: BitcoinConfig } deriving Show
@@ -54,25 +51,20 @@ isValidAddress addr = case C.base58ToAddr (TE.encodeUtf8 addr) of
 handleBadAddress :: Text -> IO()
 handleBadAddress addr = putStrLn "ERROR: address is not valid"
 
-startRound :: Bool -> Bool -> C.PrvKey -> C.Address -> IO ()
-startRound isBob isAlice prv addr = do
-    let port = if isBob then 4242 else 4243 :: PortNumber
-    chan <- P2P.startServer port
-    makeHiddenService port $ \myLocation -> do
-        putStrLn $ "hidden service location: " ++ show myLocation
-        (theirLocation, lastTx) <- discover chan myLocation isBob isAlice prv
-        putStrLn "discover done!"
-        fairExchange isBob isAlice prv chan lastTx myLocation theirLocation
-
-refract :: RefractionConfig -> Bool -> Bool -> Bool -> Text -> Text -> IO ()
-refract config isBob isAlice ignoreValidation prv addr = do
+refract :: RefractionConfig -> Bool -> Bool -> Bool -> Text -> Text -> Text -> IO ()
+refract config isBob isAlice ignoreValidation prv endAddr refundAddr = do
     let btcNetwork = network . bitcoin $ config
     TI.putStrLn $ append "INFO: Starting refraction on " btcNetwork
     when (btcNetwork == "testnet3") switchToTestnet3
     case () of
       _ | not (ignoreValidation || isValidPrivateKey prv) -> handleBadPrvkey prv
-        | not (ignoreValidation || isValidAddress addr) -> handleBadAddress addr
-        | otherwise -> startRound isBob isAlice p a
+        | not (ignoreValidation || isValidAddress endAddr) -> handleBadAddress endAddr
+      -- | not (ignoreValidation || isValidAddress startAddr) -> handleBadAddress startAddr
+        | not (ignoreValidation || isValidAddress refundAddr) -> handleBadAddress refundAddr
+        | otherwise -> prepareRounds isBob isAlice p e r
   where
+    --s = deserialize startAddr -- not used. we'll use the private key for now
+    e = deserialize endAddr
+    r = deserialize refundAddr
     p = fromMaybe undefined . C.fromWif $ TE.encodeUtf8 prv
-    a = fromMaybe undefined . C.base58ToAddr $ TE.encodeUtf8 addr
+    deserialize = fromMaybe undefined . C.base58ToAddr . TE.encodeUtf8

--- a/src/Network/Refraction/BitcoinUtils.hs
+++ b/src/Network/Refraction/BitcoinUtils.hs
@@ -1,18 +1,46 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.Refraction.BitcoinUtils
-  ( makeAddress
+  ( getUTXOs
   , makeKeyPair
+  , makeTextKeyPair
+  , SatoshiValue
+  , UTXO(..)
   ) where
 
-import Data.ByteString
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import Data.Word (Word32, Word64)
 import Network.Haskoin.Crypto
+import Network.Haskoin.Transaction
+
+type SatoshiValue = Word64
+
+data UTXO = UTXO {
+      _txOut :: TxOut
+    , _outPoint :: OutPoint
+} deriving (Show)
+
+instance Coin UTXO where
+    coinValue =  outValue . _txOut
+
 
 makeKeyPair :: IO (PrvKey, PubKey)
 makeKeyPair = genKey >>= \p -> return (p, derivePubKey p)
   where
     genKey = withSource getEntropy genPrvKey
 
-makeAddress :: IO (PrvKey, ByteString)
-makeAddress = do
+makeTextKeyPair :: IO (Text, Text)
+makeTextKeyPair = do
   (prv, pub) <- makeKeyPair
-  return (prv, addrToBase58 $ pubKeyAddr pub)
+  return ( decodeUtf8 $ encodePrvKey prv
+         , decodeUtf8 . addrToBase58 $ pubKeyAddr pub)
+
+-- TODO(hudon): This is getting outputs, they're not necessarily unspent... rename the data def?
+getUTXOs :: Tx -> [UTXO]
+getUTXOs tx =
+  let txOuts = txOut tx
+      os = zip [1..(length txOuts)] txOuts
+      hash = txHash tx
+      toUTXO (i, o) = UTXO o $ OutPoint hash (fromIntegral $ i - 1)
+  in map toUTXO os

--- a/src/Network/Refraction/Discover/Advertiser.hs
+++ b/src/Network/Refraction/Discover/Advertiser.hs
@@ -14,10 +14,11 @@ import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Network.Haskoin.Crypto (derivePubKey, PrvKey, pubKeyAddr)
 import Network.Haskoin.Transaction (Tx)
 
+import Network.Refraction.BitcoinUtils
 import Network.Refraction.Blockchain (broadcastTx, fetchUTXOs)
-import Network.Refraction.PeerToPeer (Msg)
 import Network.Refraction.Discover.Types
-import Network.Refraction.Generator (makeAdTransaction, makePairRequest, SatoshiValue)
+import Network.Refraction.Generator (makeAdTransaction, makePairRequest)
+import Network.Refraction.PeerToPeer (Msg)
 
 runAdvertiser :: Chan Msg -> PrvKey -> Location -> IO (Location, Tx)
 runAdvertiser chan prvkey loc = do

--- a/src/Network/Refraction/Discover/Respondent.hs
+++ b/src/Network/Refraction/Discover/Respondent.hs
@@ -14,9 +14,12 @@ import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Network.Haskoin.Crypto (derivePubKey, PrvKey, pubKeyAddr)
 import Network.Haskoin.Script (Script, ScriptOp(..), scriptOps)
 import Network.Haskoin.Transaction (Tx)
+
+-- TODO(hudon) make emacs autoimport?
+import Network.Refraction.BitcoinUtils
 import Network.Refraction.Blockchain (broadcastTx, findOPRETURNs, fetchUTXOs)
 import Network.Refraction.Discover.Types
-import Network.Refraction.Generator (makePairRequest, SatoshiValue)
+import Network.Refraction.Generator (makePairRequest)
 import Network.Refraction.PeerToPeer (Msg, sendMessage, unsecureSend)
 import Network.Refraction.Tor(secureConnect)
 

--- a/src/Network/Refraction/Discover/Types.hs
+++ b/src/Network/Refraction/Discover/Types.hs
@@ -10,7 +10,8 @@ module Network.Refraction.Discover.Types
 import Data.ByteString (ByteString)
 import Data.Text
 import Data.Word (Word64)
-import Network.Refraction.Generator (SatoshiValue)
+
+import Network.Refraction.BitcoinUtils
 
 -- TODO(hudon): make this fee dynamic (set by user in config?)
 -- Advertise fee

--- a/src/Network/Refraction/RoundManager.hs
+++ b/src/Network/Refraction/RoundManager.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Network.Refraction.RoundManager
+    ( prepareRounds
+    ) where
+
+import Network (PortNumber)
+import qualified Network.Haskoin.Crypto as HC
+import qualified Network.Haskoin.Transaction as HT
+
+import Network.Refraction.BitcoinUtils
+import Network.Refraction.Blockchain
+import Network.Refraction.Discover (discover)
+import Network.Refraction.FairExchange (fairExchange)
+import Network.Refraction.Generator (makeSplitTransaction)
+import qualified Network.Refraction.PeerToPeer as P2P
+import Network.Refraction.Tor (makeHiddenService)
+
+-- TODO(hudon): don't use this...
+fromEither = either (\x -> print x >> undefined) return
+
+-- TODO(hudon): actually use `addr` and `refundAddr`
+startRound :: Bool -> Bool -> HC.Address -> HC.Address -> HC.PrvKey -> UTXO -> IO ()
+startRound isBob isAlice addr refundAddr prv utxo = do
+    -- TODO(hudon): better port allocation (right now the other rounds will fail)
+    -- TODO(hudon): make the rounds not fetch all UTXOS but only the split output assigned
+    --              to the round
+    putStrLn "Round started."
+    let port = if isBob then 4142 else 4143 :: PortNumber
+    chan <- P2P.startServer port
+    putStrLn "Making hidden service..."
+    makeHiddenService port $ \myLocation -> do
+        putStrLn $ "hidden service location: " ++ show myLocation
+        (theirLocation, lastTx) <- discover chan myLocation isBob isAlice prv
+        putStrLn "discover done!"
+        fairExchange isBob isAlice prv chan lastTx myLocation theirLocation
+
+--SEE XIM PAPER:
+--m: number of parallel rounds, determined by how much money Alice has
+--n: number of sequential rounds, determined by the pool
+--delta: the mix unit. large enough to not be too expensive on fees. small enough to get participants
+-- 1. divide input amount into m mix units of size delta
+-- 2. each mix unit delta will go through n rounds
+
+prepareRounds :: Bool -> Bool -> HC.PrvKey -> HC.Address -> HC.Address -> IO ()
+prepareRounds isBob isAlice startPrv endAddr refundAddr = do
+  -- TODO: add timeout to waits across app
+  -- TODO for round timeouts (if no peer is found for that unit), the funds should go back to refundAddr
+  -- TODO(hudon): once we use the startPrvKey (or startAddr), wait for it to receive funds before continuing
+  utxos <- fetchUTXOs $ toAddr startPrv
+  splitTx <- fromEither $ makeSplitTransaction utxos [startPrv] refundAddr
+  broadcastTx splitTx
+  _ <- fetchTxWaitForRelay $ HT.txHash splitTx
+  putStrLn "Starting rounds..."
+  -- TODO(hudon): run in parallel
+  mapM_ start $ getUTXOs splitTx
+  where
+    toAddr = HC.pubKeyAddr . HC.derivePubKey
+    start = startRound isBob isAlice endAddr refundAddr startPrv

--- a/src/Network/Refraction/Tor.hs
+++ b/src/Network/Refraction/Tor.hs
@@ -21,6 +21,7 @@ whichControlPort = do
     availability <- mapM Tor.isAvailable ports
     return . fst . head . filter ((== Tor.Available) . snd) $ zip ports availability
 
+-- TODO(hudon): better failure if tor is not running... now it's a cryptic (empty list) error
 makeHiddenService :: PortNumber -> (ByteString -> IO ()) -> IO ()
 makeHiddenService privatePort f = do
     torPort <- whichControlPort

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,9 +4,12 @@ packages:
 - '.'
 - location:
     git: https://github.com/haskoin/haskoin.git
-    commit: 3f2b04cc735f5fb78a9338031d6bf7e86bd4de7c
+    commit: 7730c8c070a8d71b16c4df9c2637881ac47878e3
   subdirs:
   - haskoin-core
   extra-dep: true
-extra-deps: []
-resolver: lts-7.2
+extra-deps:
+  - murmur3-1.0.3
+  - pbkdf-1.1.1.1
+  - secp256k1-0.4.8
+resolver: lts-8.13

--- a/tests/Network/Refraction/GeneratorSpec.hs
+++ b/tests/Network/Refraction/GeneratorSpec.hs
@@ -8,6 +8,7 @@ import Network.Haskoin.Crypto
 import Network.Haskoin.Script
 import Network.Haskoin.Transaction
 import Network.Refraction.BitcoinUtils
+import qualified Network.Refraction.BitcoinUtils
 import qualified Network.Refraction.Generator as G
 import Test.Hspec
 
@@ -16,7 +17,7 @@ spec = do
     describe "mkInput" $ do
         it "returns Left if non-decodable" $ do
             let txout = TxOut preAdValue $ S.encode "foo" -- bad output script
-                badUTXO = G.UTXO txout undefined
+                badUTXO = UTXO txout undefined
             G.mkInput badUTXO `shouldSatisfy` isLeft
     describe "makeAdTransaction" $ do
         it "returns change to signatory" $ do
@@ -46,7 +47,7 @@ preAdTxHash = read "TxHash \"aa89f9878323075e109efcbd44c7804db4bea9c85910d002d88
 preAdUTXO =
     let txout = TxOut preAdValue $ encodeOutputBS $ PayPKHash advertiserAddress
         op = OutPoint preAdTxHash 1
-    in G.UTXO txout op
+    in UTXO txout op
 
 adFee = 10000000 :: SatoshiValue -- 0.1 btc
 

--- a/tests/Network/Refraction/GeneratorSpec.hs
+++ b/tests/Network/Refraction/GeneratorSpec.hs
@@ -7,6 +7,7 @@ import Network.Haskoin.Constants
 import Network.Haskoin.Crypto
 import Network.Haskoin.Script
 import Network.Haskoin.Transaction
+import Network.Refraction.BitcoinUtils
 import qualified Network.Refraction.Generator as G
 import Test.Hspec
 
@@ -40,14 +41,14 @@ advertiserPrvKey = read "PrvKey \"KzVhFsdDKRsLQPBu7Fkhm4S2fP5muXMLkikPfcRa8Kn72Q
 
 advertiserAddress = pubKeyAddr $ derivePubKey advertiserPrvKey
 
-preAdValue = 100000000 :: G.SatoshiValue -- 1 btc
+preAdValue = 100000000 :: SatoshiValue -- 1 btc
 preAdTxHash = read "TxHash \"aa89f9878323075e109efcbd44c7804db4bea9c85910d002d888b9fa70087570\""
 preAdUTXO =
     let txout = TxOut preAdValue $ encodeOutputBS $ PayPKHash advertiserAddress
         op = OutPoint preAdTxHash 1
     in G.UTXO txout op
 
-adFee = 10000000 :: G.SatoshiValue -- 0.1 btc
+adFee = 10000000 :: SatoshiValue -- 0.1 btc
 
 prepareAdTx :: Tx
 prepareAdTx =


### PR DESCRIPTION
- This takes the UTXOS on the given prvkey and joins them into a tx that has
  outputs that are all of value `mixUnit` + an output to the refund address
- TODO: fix the rounds to be in parallel. Right now the first round gobbles up
  all the split outputs AND we don't have smart port allocation so tor calls to
  create hidden services fails as well

ref #60 