### PR TITLE
Pick any available port, not just 4142/4143

### DIFF
--- a/src/Network/Refraction/PeerToPeer.hs
+++ b/src/Network/Refraction/PeerToPeer.hs
@@ -33,15 +33,18 @@ serverLoop sock chan = do
     forkIO $ runConn conn chan
     serverLoop sock chan
 
-startServer :: PortNumber -> IO (Chan Msg)
-startServer port = do
+-- | Forks a server and returns a channel. The server accepts incoming connections and
+--   forwards any incoming messages to the channel.
+startServer :: IO (Chan Msg, PortNumber)
+startServer = do
     sock <- socket AF_INET Stream 0
     setSocketOption sock ReuseAddr 1
-    bind sock (SockAddrInet port iNADDR_ANY)
+    bind sock (SockAddrInet aNY_PORT iNADDR_ANY)
     listen sock 2
     chan <- newChan
     forkIO $ serverLoop sock chan
-    return chan
+    chosenPort <- socketPort sock
+    return (chan, chosenPort)
 
 sendMessage :: Msg -> Socket -> IO ()
 sendMessage m sock = do

--- a/src/Network/Refraction/RoundManager.hs
+++ b/src/Network/Refraction/RoundManager.hs
@@ -3,7 +3,6 @@ module Network.Refraction.RoundManager
     ( prepareRounds
     ) where
 
-import Network (PortNumber)
 import qualified Network.Haskoin.Crypto as HC
 import qualified Network.Haskoin.Transaction as HT
 
@@ -25,8 +24,7 @@ startRound isBob isAlice addr refundAddr prv utxo = do
     -- TODO(hudon): make the rounds not fetch all UTXOS but only the split output assigned
     --              to the round
     putStrLn "Round started."
-    let port = if isBob then 4142 else 4143 :: PortNumber
-    chan <- P2P.startServer port
+    (chan, port) <- P2P.startServer
     putStrLn "Making hidden service..."
     makeHiddenService port $ \myLocation -> do
         putStrLn $ "hidden service location: " ++ show myLocation

--- a/src/Network/Refraction/Tor.hs
+++ b/src/Network/Refraction/Tor.hs
@@ -26,6 +26,7 @@ makeHiddenService :: PortNumber -> (ByteString -> IO ()) -> IO ()
 makeHiddenService privatePort f = do
     torPort <- whichControlPort
     Tor.withSession torPort $ \controlSock -> do
+        -- Port 80 is "virtual port" and not an actual port on the host
         onion <- Tor.mapOnion controlSock 80 (toInteger privatePort) False Nothing
         f . encodeUtf8 $ append (toText onion) ".onion"
 


### PR DESCRIPTION
- 2 hard-coded ports were always chosen for bob/alice, which prevented
rounds from running in parallel due to port conflict